### PR TITLE
Search input strategy

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 
     <script src="https://unpkg.com/jquery@3.4.0/dist/jquery.min.js"></script>
     <script src="https://unpkg.com/oojs@3.0.0/dist/oojs.jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-throttle-debounce/1.1/jquery.ba-throttle-debounce.min.js"></script>
     <script src="https://unpkg.com/oojs-ui@0.34.0/dist/oojs-ui.js"></script>
     <script src="https://unpkg.com/oojs-ui@0.34.0/dist/oojs-ui-wikimediaui.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/oojs-ui@0.34.0/dist/oojs-ui-wikimediaui.css">


### PR DESCRIPTION
Provide a search input field alongside the task type filters, perform
searches with hastemplate appended. The idea is to mimic the search UI
from MobileFrontend and provide dynamic feedback to the user until
they find tasks they are interested in.

We could consider using topics to kick off some of the searches,
e.g. selecting "Filosofie" from the MenuTagMultiselectWidget would
prefill the serach input with "Filosofie" and execute a search.